### PR TITLE
New felix config for process path

### DIFF
--- a/pkg/apis/projectcalico/v3/felixconfig.go
+++ b/pkg/apis/projectcalico/v3/felixconfig.go
@@ -410,6 +410,14 @@ type FelixConfigurationSpec struct {
 	FlowLogsCollectProcessInfo *bool `json:"flowLogsCollectProcessInfo,omitempty" validate:"omitempty"`
 	// FlowLogsCollectTcpStats enables flow logs reporting TCP socket stats
 	FlowLogsCollectTcpStats *bool `json:"flowLogsCollectTcpStats,omitempty" validate:"omitempty"`
+	// When FlowLogsCollectProcessPath and FlowLogsCollectProcessInfo are
+	// both enabled, each flow log will include information about the process
+	// that is sending or receiving the packets in that flow: the
+	// `process_name` field will contain the full path of the process
+	// executable, and the `process_args` field will have the arguments with
+	// which the executable was invoked.  Process information will not be
+	// reported for connections which use raw sockets.
+	FlowLogsCollectProcessPath *bool `json:"flowLogsCollectProcessPath,omitempty" validate:"omitempty"`
 
 	// FlowLogsFileEnabled when set to true, enables logging flow logs to a file. If false no flow logging to file will occur.
 	FlowLogsFileEnabled *bool `json:"flowLogsFileEnabled,omitempty"`

--- a/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
+++ b/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
@@ -1533,6 +1533,11 @@ func (in *FelixConfigurationSpec) DeepCopyInto(out *FelixConfigurationSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.FlowLogsCollectProcessPath != nil {
+		in, out := &in.FlowLogsCollectProcessPath, &out.FlowLogsCollectProcessPath
+		*out = new(bool)
+		**out = **in
+	}
 	if in.FlowLogsFileEnabled != nil {
 		in, out := &in.FlowLogsFileEnabled, &out.FlowLogsFileEnabled
 		*out = new(bool)

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -3490,6 +3490,13 @@ func schema_pkg_apis_projectcalico_v3_FelixConfigurationSpec(ref common.Referenc
 							Format:      "",
 						},
 					},
+					"flowLogsCollectProcessPath": {
+						SchemaProps: spec.SchemaProps{
+							Description: "When FlowLogsCollectProcessPath and FlowLogsCollectProcessInfo are both enabled, each flow log will include information about the process that is sending or receiving the packets in that flow: the `process_name` field will contain the full path of the process executable, and the `process_args` field will have the arguments with which the executable was invoked.  Process information will not be reported for connections which use raw sockets.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"flowLogsFileEnabled": {
 						SchemaProps: spec.SchemaProps{
 							Description: "FlowLogsFileEnabled when set to true, enables logging flow logs to a file. If false no flow logging to file will occur.",


### PR DESCRIPTION
Add a new felix config `FLOWLOGSCOLLECTPROCESSPATH`, which when enabled will collect the process path, args to flowlogs.