### PR TITLE
New felix config for process args aggregation in flowlogs

### DIFF
--- a/pkg/apis/projectcalico/v3/felixconfig.go
+++ b/pkg/apis/projectcalico/v3/felixconfig.go
@@ -467,6 +467,9 @@ type FelixConfigurationSpec struct {
 	// FlowLogsFilePerFlowProcessLimit, is used to specify the maximum number of flow log entries with distinct process information
 	// beyond which process information will be aggregated. [Default: 2]
 	FlowLogsFilePerFlowProcessLimit *int `json:"flowLogsFilePerFlowProcessLimit,omitempty" validate:"omitempty"`
+	// FlowLogsFilePerFlowProcessArgsLimit is used to specify the maximum number of distinct process args that will appear in the flowLogs.
+	// Default value is 5
+	FlowLogsFilePerFlowProcessArgsLimit *int `json:"flowLogsFilePerFlowProcessLimit,omitempty" validate:"omitempty"`
 
 	// WindowsFlowLogsFileDirectory sets the directory where flow logs files are stored on Windows nodes. [Default: "c:\\TigeraCalico\\flowlogs"].
 	WindowsFlowLogsFileDirectory string `json:"windowsFlowLogsFileDirectory,omitempty"`

--- a/pkg/apis/projectcalico/v3/felixconfig.go
+++ b/pkg/apis/projectcalico/v3/felixconfig.go
@@ -469,7 +469,7 @@ type FelixConfigurationSpec struct {
 	FlowLogsFilePerFlowProcessLimit *int `json:"flowLogsFilePerFlowProcessLimit,omitempty" validate:"omitempty"`
 	// FlowLogsFilePerFlowProcessArgsLimit is used to specify the maximum number of distinct process args that will appear in the flowLogs.
 	// Default value is 5
-	FlowLogsFilePerFlowProcessArgsLimit *int `json:"flowLogsFilePerFlowProcessLimit,omitempty" validate:"omitempty"`
+	FlowLogsFilePerFlowProcessArgsLimit *int `json:"flowLogsFilePerFlowProcessArgsLimit,omitempty" validate:"omitempty"`
 
 	// WindowsFlowLogsFileDirectory sets the directory where flow logs files are stored on Windows nodes. [Default: "c:\\TigeraCalico\\flowlogs"].
 	WindowsFlowLogsFileDirectory string `json:"windowsFlowLogsFileDirectory,omitempty"`

--- a/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
+++ b/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
@@ -1613,6 +1613,11 @@ func (in *FelixConfigurationSpec) DeepCopyInto(out *FelixConfigurationSpec) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.FlowLogsFilePerFlowProcessArgsLimit != nil {
+		in, out := &in.FlowLogsFilePerFlowProcessArgsLimit, &out.FlowLogsFilePerFlowProcessArgsLimit
+		*out = new(int)
+		**out = **in
+	}
 	if in.WindowsDNSExtraTTL != nil {
 		in, out := &in.WindowsDNSExtraTTL, &out.WindowsDNSExtraTTL
 		*out = new(metav1.Duration)

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -3602,7 +3602,7 @@ func schema_pkg_apis_projectcalico_v3_FelixConfigurationSpec(ref common.Referenc
 							Format:      "int32",
 						},
 					},
-					"flowLogsFilePerFlowProcessLimit": {
+					"flowLogsFilePerFlowProcessArgsLimit": {
 						SchemaProps: spec.SchemaProps{
 							Description: "FlowLogsFilePerFlowProcessArgsLimit is used to specify the maximum number of distinct process args that will appear in the flowLogs. Default value is 5",
 							Type:        []string{"integer"},

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -3602,6 +3602,13 @@ func schema_pkg_apis_projectcalico_v3_FelixConfigurationSpec(ref common.Referenc
 							Format:      "int32",
 						},
 					},
+					"flowLogsFilePerFlowProcessLimit": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FlowLogsFilePerFlowProcessArgsLimit is used to specify the maximum number of distinct process args that will appear in the flowLogs. Default value is 5",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"windowsFlowLogsFileDirectory": {
 						SchemaProps: spec.SchemaProps{
 							Description: "WindowsFlowLogsFileDirectory sets the directory where flow logs files are stored on Windows nodes. [Default: \"c:\\TigeraCalico\\flowlogs\"].",


### PR DESCRIPTION
This new Felix config, FlowLogsFilePerFlowProcessArgsLimit defines the number of uniqure args that will be aggregated in the flowlogs. Default value is 5.