### PR TITLE
Automated cherry pick of #27: Begin development on v3.10.0 #32: Don't require DNSPolicyNFqueueID to be set #33: change validation to not require the DNSPOlicyNfqueueID

### DIFF
--- a/pkg/apis/projectcalico/v3/felixconfig.go
+++ b/pkg/apis/projectcalico/v3/felixconfig.go
@@ -323,6 +323,10 @@ type FelixConfigurationSpec struct {
 	DebugSimulateCalcGraphHangAfter *metav1.Duration `json:"debugSimulateCalcGraphHangAfter,omitempty" configv1timescale:"seconds"`
 	DebugSimulateDataplaneHangAfter *metav1.Duration `json:"debugSimulateDataplaneHangAfter,omitempty" configv1timescale:"seconds"`
 
+	// DNSPolicyNfqueueID is the NFQUEUE ID to use for DNS Policy re-evaluation when the domains IP hasn't been programmed
+	// to ipsets yet. [Default: 100]
+	DNSPolicyNfqueueID *int `json:"dnsPolicyNfqueueID" validate:"omitempty,gte=0,lte=65535"`
+
 	IptablesNATOutgoingInterfaceFilter string `json:"iptablesNATOutgoingInterfaceFilter,omitempty" validate:"omitempty,ifaceFilter"`
 
 	// SidecarAccelerationEnabled enables experimental sidecar acceleration [Default: false]

--- a/pkg/apis/projectcalico/v3/felixconfig.go
+++ b/pkg/apis/projectcalico/v3/felixconfig.go
@@ -325,7 +325,7 @@ type FelixConfigurationSpec struct {
 
 	// DNSPolicyNfqueueID is the NFQUEUE ID to use for DNS Policy re-evaluation when the domains IP hasn't been programmed
 	// to ipsets yet. [Default: 100]
-	DNSPolicyNfqueueID *int `json:"dnsPolicyNfqueueID" validate:"omitempty,gte=0,lte=65535"`
+	DNSPolicyNfqueueID *int `json:"dnsPolicyNfqueueID,omitempty" validate:"gte=0,lte=65535"`
 
 	IptablesNATOutgoingInterfaceFilter string `json:"iptablesNATOutgoingInterfaceFilter,omitempty" validate:"omitempty,ifaceFilter"`
 

--- a/pkg/apis/projectcalico/v3/felixconfig.go
+++ b/pkg/apis/projectcalico/v3/felixconfig.go
@@ -325,7 +325,7 @@ type FelixConfigurationSpec struct {
 
 	// DNSPolicyNfqueueID is the NFQUEUE ID to use for DNS Policy re-evaluation when the domains IP hasn't been programmed
 	// to ipsets yet. [Default: 100]
-	DNSPolicyNfqueueID *int `json:"dnsPolicyNfqueueID,omitempty" validate:"gte=0,lte=65535"`
+	DNSPolicyNfqueueID *int `json:"dnsPolicyNfqueueID,omitempty" validate:"omitempty,gte=0,lte=65535"`
 
 	IptablesNATOutgoingInterfaceFilter string `json:"iptablesNATOutgoingInterfaceFilter,omitempty" validate:"omitempty,ifaceFilter"`
 

--- a/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
+++ b/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
@@ -1737,6 +1737,11 @@ func (in *FelixConfigurationSpec) DeepCopyInto(out *FelixConfigurationSpec) {
 		*out = new(metav1.Duration)
 		**out = **in
 	}
+	if in.DNSPolicyNfqueueID != nil {
+		in, out := &in.DNSPolicyNfqueueID, &out.DNSPolicyNfqueueID
+		*out = new(int)
+		**out = **in
+	}
 	if in.SidecarAccelerationEnabled != nil {
 		in, out := &in.SidecarAccelerationEnabled, &out.SidecarAccelerationEnabled
 		*out = new(bool)

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -4486,7 +4486,6 @@ func schema_pkg_apis_projectcalico_v3_FelixConfigurationSpec(ref common.Referenc
 						},
 					},
 				},
-				Required: []string{"dnsPolicyNfqueueID"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -3775,6 +3775,13 @@ func schema_pkg_apis_projectcalico_v3_FelixConfigurationSpec(ref common.Referenc
 							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
+					"dnsPolicyNfqueueID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DNSPolicyNfqueueID is the NFQUEUE ID to use for DNS Policy re-evaluation when the domains IP hasn't been programmed to ipsets yet. [Default: 100]",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"iptablesNATOutgoingInterfaceFilter": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
@@ -4479,6 +4486,7 @@ func schema_pkg_apis_projectcalico_v3_FelixConfigurationSpec(ref common.Referenc
 						},
 					},
 				},
+				Required: []string{"dnsPolicyNfqueueID"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
Cherry pick of #27 #32 #33 on release-calient-v3.9.

#27: Begin development on v3.10.0
#32: Don't require DNSPolicyNFqueueID to be set
#33: change validation to not require the DNSPOlicyNfqueueID