### PR TITLE
Update PacketCapture API with an enum to determine the state of the t…

### DIFF
--- a/pkg/apis/projectcalico/v3/packetcapture.go
+++ b/pkg/apis/projectcalico/v3/packetcapture.go
@@ -13,6 +13,16 @@ const (
 	KindPacketCaptureList = "PacketCaptureList"
 )
 
+// PacketCaptureState represents the state of the PacketCapture
+type PacketCaptureState string
+
+const (
+	// PacketCaptureStateCapturing represents the active state of a PacketCapture of capturing traffic
+	PacketCaptureStateCapturing PacketCaptureState = "Capturing"
+	// PacketCaptureStateInactive represents the inactive state of a PacketCapture of not capturing traffic
+	PacketCaptureStateInactive = "Inactive"
+)
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -110,10 +120,11 @@ type PacketCaptureFile struct {
 	// Rotated capture files name will contain an index matching the rotation timestamp.
 	FileNames []string `json:"fileNames,omitempty" validate:"omitempty,dive"`
 
-	// Determines whether a PacketCapture is capturing traffic or not from any interface
-	// attached to the current node. In addition, the value will be set to true if the current time
-	// of capture is bounded by the interval defined by startTime and endTime
-	Active bool `json:"active,omitempty" validate:"omitempty"`
+	// Determines whether a PacketCapture is capturing traffic from any interface
+	// attached to the current node
+
+	// +kubebuilder:validation:Enum=Capturing;Inactive
+	State *PacketCaptureState `json:"state,omitempty" validate:"omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
+++ b/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
@@ -3774,6 +3774,11 @@ func (in *PacketCaptureFile) DeepCopyInto(out *PacketCaptureFile) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.State != nil {
+		in, out := &in.State, &out.State
+		*out = new(PacketCaptureState)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -7258,11 +7258,10 @@ func schema_pkg_apis_projectcalico_v3_PacketCaptureFile(ref common.ReferenceCall
 							},
 						},
 					},
-					"active": {
+					"state": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Determines whether a PacketCapture is capturing traffic or not from any interface attached to the current node. In addition, the value will be set to true if the current time of capture is bounded by the interval defined by startTime and endTime",
-							Type:        []string{"boolean"},
-							Format:      "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 				},


### PR DESCRIPTION
…raffic

## Description
- Use an Enum to show the state of the PacketCapture (Capturing/Inactive)

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
