### PR TITLE
Add a new state for PacketCapture state

### DIFF
--- a/pkg/apis/projectcalico/v3/packetcapture.go
+++ b/pkg/apis/projectcalico/v3/packetcapture.go
@@ -26,6 +26,9 @@ const (
 	PacketCaptureStateScheduled = "Scheduled"
 	// PacketCaptureStateError represents the error state of a PacketCapture
 	PacketCaptureStateError = "Error"
+	// PacketCaptureStateWaitingForTraffic represents the active state of a PacketCapture of capturing from a live
+	// interface, but waiting for traffic on that interface
+	PacketCaptureStateWaitingForTraffic = "WaitingForTraffic"
 )
 
 // +genclient
@@ -130,7 +133,7 @@ type PacketCaptureFile struct {
 	// Determines whether a PacketCapture is capturing traffic from any interface
 	// attached to the current node
 
-	// +kubebuilder:validation:Enum=Capturing;Finished;Scheduled;Error
+	// +kubebuilder:validation:Enum=Capturing;Finished;Scheduled;Error;WaitingForTraffic
 	State *PacketCaptureState `json:"state,omitempty" validate:"omitempty"`
 }
 


### PR DESCRIPTION
## Description
Introduce a new state to inform the user that PacketCapture is still
waiting for the first packet to arrive

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
