### PR TITLE
Add FlowLogsFilePostSNATPortLimit felix configuration

### DIFF
--- a/pkg/apis/projectcalico/v3/felixconfig.go
+++ b/pkg/apis/projectcalico/v3/felixconfig.go
@@ -477,6 +477,9 @@ type FelixConfigurationSpec struct {
 	// FlowLogsFilePerFlowProcessArgsLimit is used to specify the maximum number of distinct process args that will appear in the flowLogs.
 	// Default value is 5
 	FlowLogsFilePerFlowProcessArgsLimit *int `json:"flowLogsFilePerFlowProcessArgsLimit,omitempty" validate:"omitempty"`
+	// FlowLogsFilePostSNATPortLimit is used to specify the maximum number of distinct post SNAT ports that will appear
+	// in the flowLogs. Default value is 3
+	FlowLogsFilePostSNATPortLimit *int `json:"flowLogsFilePerFlowProcessArgsLimit,omitempty" validate:"omitempty"`
 
 	// WindowsFlowLogsFileDirectory sets the directory where flow logs files are stored on Windows nodes. [Default: "c:\\TigeraCalico\\flowlogs"].
 	WindowsFlowLogsFileDirectory string `json:"windowsFlowLogsFileDirectory,omitempty"`

--- a/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
+++ b/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
@@ -2164,6 +2164,11 @@ func (in *FelixConfigurationSpec) DeepCopyInto(out *FelixConfigurationSpec) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.FlowLogsFilePostSNATPortLimit != nil {
+		in, out := &in.FlowLogsFilePostSNATPortLimit, &out.FlowLogsFilePostSNATPortLimit
+		*out = new(int)
+		**out = **in
+	}
 	if in.WindowsDNSExtraTTL != nil {
 		in, out := &in.WindowsDNSExtraTTL, &out.WindowsDNSExtraTTL
 		*out = new(metav1.Duration)

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -4625,6 +4625,13 @@ func schema_pkg_apis_projectcalico_v3_FelixConfigurationSpec(ref common.Referenc
 							Format:      "int32",
 						},
 					},
+					"flowLogsFilePerFlowProcessArgsLimit": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FlowLogsFilePostSNATPortLimit is used to specify the maximum number of distinct post SNAT ports that will appear in the flowLogs. Default value is 3",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"windowsFlowLogsFileDirectory": {
 						SchemaProps: spec.SchemaProps{
 							Description: "WindowsFlowLogsFileDirectory sets the directory where flow logs files are stored on Windows nodes. [Default: \"c:\\TigeraCalico\\flowlogs\"].",


### PR DESCRIPTION
FlowLogsFilePostSNATPortLimit sets the number of post SNAT ports that will be logged in a flow log.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
