### PR TITLE
[release-calient-v3.14] Automated cherry pick of #108: Add operatorNamespace to ManagedClusterSpec

### DIFF
--- a/pkg/apis/projectcalico/v3/managedcluster.go
+++ b/pkg/apis/projectcalico/v3/managedcluster.go
@@ -46,6 +46,9 @@ type ManagedClusterSpec struct {
 	// Field to store dynamically generated manifest for installing component into
 	// the actual application cluster corresponding to this Managed Cluster
 	InstallationManifest string `json:"installationManifest,omitempty"`
+	// The namespace of the managed cluster's operator. This value is used in
+	// the generation of the InstallationManifest.
+	OperatorNamespace string `json:"operatorNamespace,omitempty"`
 }
 
 type ManagedClusterStatus struct {

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -7864,6 +7864,13 @@ func schema_pkg_apis_projectcalico_v3_ManagedClusterSpec(ref common.ReferenceCal
 							Format:      "",
 						},
 					},
+					"operatorNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The namespace of the managed cluster's operator. This value is used in the generation of the InstallationManifest.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Cherry pick of #108 on release-calient-v3.14.

#108: Add operatorNamespace to ManagedClusterSpec