### PR TITLE
Set k8s.io/apiserver require to real value

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,18 +10,14 @@ require (
 	github.com/onsi/gomega v1.10.1
 	k8s.io/api v0.23.2
 	k8s.io/apimachinery v0.23.2
-	k8s.io/apiserver v0.0.0-00010101000000-000000000000
+	k8s.io/apiserver v0.23.2
 	k8s.io/client-go v0.23.2
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65
 )
 
 replace (
-	k8s.io/api => k8s.io/api v0.23.2
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.23.2
-	k8s.io/apimachinery => k8s.io/apimachinery v0.23.2
-	k8s.io/apiserver => k8s.io/apiserver v0.23.2
 	k8s.io/cli-runtime => k8s.io/cli-runtime v0.23.2
-	k8s.io/client-go => k8s.io/client-go v0.23.2
 	k8s.io/cloud-provider => k8s.io/cloud-provider v0.23.2
 	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.23.2
 	k8s.io/code-generator => k8s.io/code-generator v0.23.2


### PR DESCRIPTION
The machinery for building operator reference documentation chokes on the v0.0.0-00010101000000-000000000000 which is a placeholder when a replace is specified but no require is defined for the same.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
