### PR TITLE
Auto-approve API sync PRs

### DIFF
--- a/.github/workflows/sync-calico-api.yml
+++ b/.github/workflows/sync-calico-api.yml
@@ -63,6 +63,7 @@ jobs:
         run: make gen-files
 
       - uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0  # v8.1.0
+        id: cpr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Automatic API update from tigera/calico-private ${{ matrix.branch }}"
@@ -76,3 +77,21 @@ jobs:
             Triggered by scheduled workflow.
           labels: docs-not-required,release-note-not-required,merge-when-ready,delete-branch
           delete-branch: true
+
+      # The PR author is github-actions[bot] (the GITHUB_TOKEN identity above), so
+      # it can't approve its own PR, and the Actions token can't approve PRs anyway.
+      # Approve as marvin-tigera (MARVIN_PAT) so Marvin merges it once CI is green.
+      # branch protection has dismiss_stale_reviews off, so a single approval persists
+      # across the hourly content updates -- the reviewDecision guard keeps reruns quiet.
+      - name: Auto-approve so Marvin merges once CI passes
+        if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
+        env:
+          GH_TOKEN: ${{ secrets.MARVIN_PAT }}
+          PR: ${{ steps.cpr.outputs.pull-request-number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ "$(gh pr view "$PR" -R "$REPO" --json reviewDecision -q .reviewDecision)" = "APPROVED" ]; then
+            echo "PR #$PR already approved; nothing to do."
+            exit 0
+          fi
+          gh pr review "$PR" -R "$REPO" --approve


### PR DESCRIPTION
The hourly API sync PRs sat waiting on a manual approval before Marvin would merge them. This adds an auto-approve step (as marvin-tigera, since the bot can't approve its own PR and the Actions token can't approve at all) so they merge unattended once CI is green. Branch protection still gates the merge on the required check, so nothing merges on red CI.

```release-note
None
```
